### PR TITLE
fix(file): Exclude ES template for maven resource filtering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,15 @@
 			<resource>
 				<directory>src/main/resources</directory>
 				<filtering>true</filtering>
+				<includes>
+					<include>plugin.properties</include>
+				</includes>
+			</resource>
+			<resource>
+				<directory>src/main/resources</directory>
+				<excludes>
+					<exclude>plugin.properties</exclude>
+				</excludes>
 			</resource>
 		</resources>
 		<plugins>


### PR DESCRIPTION
Closes gravitee-io/issues#5181