### PR TITLE
fix: skip jackson filter if no field filtering is required

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
 	<properties>
 		<gravitee-bom.version>1.5-SNAPSHOT</gravitee-bom.version>
-		<gravitee-gateway-api.version>1.30.0-SNAPSHOT</gravitee-gateway-api.version>
+		<gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
 		<gravitee-reporter-api.version>1.22.0-SNAPSHOT</gravitee-reporter-api.version>
 		<gravitee-common.version>1.24.0-SNAPSHOT</gravitee-common.version>
 		<gravitee-node.version>1.15.1</gravitee-node.version>

--- a/src/main/java/io/gravitee/reporter/file/formatter/json/JsonFormatter.java
+++ b/src/main/java/io/gravitee/reporter/file/formatter/json/JsonFormatter.java
@@ -38,12 +38,15 @@ public class JsonFormatter<T extends Reportable> extends AbstractFormatter<T> {
     private final ObjectMapper mapper = new ObjectMapper();
 
     public JsonFormatter(final Rules rules) {
-        mapper.addMixIn(Reportable.class, FieldFilterMixin.class);
-        mapper.addMixIn(Request.class, FieldFilterMixin.class);
-        mapper.addMixIn(Response.class, FieldFilterMixin.class);
-        mapper.addMixIn(EndpointStatus.class, FieldFilterMixin.class);
-        mapper.addMixIn(Step.class, FieldFilterMixin.class);
-        mapper.setFilterProvider(new FieldFilterProvider(rules));
+        if (rules != null && rules.containsRules()) {
+            mapper.addMixIn(Reportable.class, FieldFilterMixin.class);
+            mapper.addMixIn(Request.class, FieldFilterMixin.class);
+            mapper.addMixIn(Response.class, FieldFilterMixin.class);
+            mapper.addMixIn(EndpointStatus.class, FieldFilterMixin.class);
+            mapper.addMixIn(Step.class, FieldFilterMixin.class);
+            mapper.setFilterProvider(new FieldFilterProvider(rules));
+        }
+
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }
 

--- a/src/test/java/io/gravitee/reporter/file/formatter/json/JsonFormatterTest.java
+++ b/src/test/java/io/gravitee/reporter/file/formatter/json/JsonFormatterTest.java
@@ -45,8 +45,8 @@ public class JsonFormatterTest {
 
     @Test
     public void shouldRenameField() throws JsonProcessingException {
-        Rules rules = Mockito.mock(Rules.class);
-        Mockito.when(rules.getRenameFields()).thenReturn(Maps.<String, String>builder().put("application", "app").build());
+        Rules rules = new Rules();
+        rules.setRenameFields(Maps.<String, String>builder().put("application", "app").build());
 
         JsonFormatter<Metrics> formatter = new JsonFormatter<>(rules);
 
@@ -64,8 +64,8 @@ public class JsonFormatterTest {
 
     @Test
     public void shouldFilterField() throws JsonProcessingException {
-        Rules rules = Mockito.mock(Rules.class);
-        Mockito.when(rules.getExcludeFields()).thenReturn(Collections.singleton("application"));
+        Rules rules = new Rules();
+        rules.setExcludeFields(Collections.singleton("application"));
 
         JsonFormatter<Metrics> formatter = new JsonFormatter<>(rules);
 
@@ -82,8 +82,8 @@ public class JsonFormatterTest {
 
     @Test
     public void shouldExcludeAllFields() throws JsonProcessingException {
-        Rules rules = Mockito.mock(Rules.class);
-        Mockito.when(rules.getExcludeFields()).thenReturn(Collections.singleton("*"));
+        Rules rules = new Rules();
+        rules.setExcludeFields(Collections.singleton("*"));
 
         JsonFormatter<Metrics> formatter = new JsonFormatter<>(rules);
 
@@ -100,9 +100,9 @@ public class JsonFormatterTest {
 
     @Test
     public void shouldExcludeAndIncludeSameField() throws JsonProcessingException {
-        Rules rules = Mockito.mock(Rules.class);
-        Mockito.when(rules.getExcludeFields()).thenReturn(Collections.singleton("api"));
-        Mockito.when(rules.getIncludeFields()).thenReturn(Collections.singleton("api"));
+        Rules rules = new Rules();
+        rules.setExcludeFields(Collections.singleton("api"));
+        rules.setIncludeFields(Collections.singleton("api"));
 
         JsonFormatter<Metrics> formatter = new JsonFormatter<>(rules);
 
@@ -119,9 +119,9 @@ public class JsonFormatterTest {
 
     @Test
     public void shouldExcludeAllFields_butIncludeOneField() throws JsonProcessingException {
-        Rules rules = Mockito.mock(Rules.class);
-        Mockito.when(rules.getExcludeFields()).thenReturn(Collections.singleton("*"));
-        Mockito.when(rules.getIncludeFields()).thenReturn(Collections.singleton("api"));
+        Rules rules = new Rules();
+        rules.setExcludeFields(Collections.singleton("*"));
+        rules.setIncludeFields(Collections.singleton("api"));
 
         JsonFormatter<Metrics> formatter = new JsonFormatter<>(rules);
 
@@ -139,8 +139,8 @@ public class JsonFormatterTest {
 
     @Test
     public void shouldExcludeNestedFields() throws JsonProcessingException {
-        Rules rules = Mockito.mock(Rules.class);
-        Mockito.when(rules.getExcludeFields()).thenReturn(Collections.singleton("clientRequest"));
+        Rules rules = new Rules();
+        rules.setExcludeFields(Collections.singleton("clientRequest"));
 
         JsonFormatter<Log> formatter = new JsonFormatter<>(rules);
 
@@ -166,8 +166,8 @@ public class JsonFormatterTest {
 
     @Test
     public void shouldExcludeNestedProperty() throws JsonProcessingException {
-        Rules rules = Mockito.mock(Rules.class);
-        Mockito.when(rules.getExcludeFields()).thenReturn(Collections.singleton("clientRequest.uri"));
+        Rules rules = new Rules();
+        rules.setExcludeFields(Collections.singleton("clientRequest.uri"));
 
         JsonFormatter<Log> formatter = new JsonFormatter<>(rules);
 
@@ -193,8 +193,8 @@ public class JsonFormatterTest {
 
     @Test
     public void shouldRenameNestedPrgetExcludeFieldsoperty() throws JsonProcessingException {
-        Rules rules = Mockito.mock(Rules.class);
-        Mockito.when(rules.getRenameFields()).thenReturn(Maps.<String, String>builder().put("clientRequest.uri", "path").build());
+        Rules rules = new Rules();
+        rules.setRenameFields(Maps.<String, String>builder().put("clientRequest.uri", "path").build());
 
         JsonFormatter<Log> formatter = new JsonFormatter<>(rules);
 


### PR DESCRIPTION
It appears that even if the jackson filter does nothing, it costs to simply register it

Closes gravitee-io/issues#6911