### PR TITLE
use the right version of gravitee-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 	<name>Gravitee.io APIM - Reporter - File</name>
 
 	<properties>
-		<gravitee-bom.version>1.5-SNAPSHOT</gravitee-bom.version>
+		<gravitee-bom.version>2.4</gravitee-bom.version>
 		<gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
 		<gravitee-reporter-api.version>1.22.0</gravitee-reporter-api.version>
 		<gravitee-common.version>1.24.0</gravitee-common.version>


### PR DESCRIPTION
**Issue**

N/A

**Description**

Use the right version of gravitee-bom
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.5.1-fix-bom-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-file/2.5.1-fix-bom-version-SNAPSHOT/gravitee-reporter-file-2.5.1-fix-bom-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
