### PR TITLE
fix: use HttpHeadersSerializer to serialize HttpHeaders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
 	<groupId>io.gravitee.reporter</groupId>
 	<artifactId>gravitee-reporter-file</artifactId>
-	<version>2.5.1</version>
+	<version>2.5.2-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Gravitee.io APIM - Reporter - File</name>
@@ -36,7 +36,7 @@
 	<properties>
 		<gravitee-bom.version>2.5</gravitee-bom.version>
 		<gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
-		<gravitee-reporter-api.version>1.22.0</gravitee-reporter-api.version>
+		<gravitee-reporter-api.version>1.23.0</gravitee-reporter-api.version>
 		<gravitee-common.version>1.24.0</gravitee-common.version>
 		<gravitee-node.version>1.15.1</gravitee-node.version>
 

--- a/src/main/java/io/gravitee/reporter/file/formatter/json/JsonFormatter.java
+++ b/src/main/java/io/gravitee/reporter/file/formatter/json/JsonFormatter.java
@@ -18,6 +18,8 @@ package io.gravitee.reporter.file.formatter.json;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.reporter.api.Reportable;
 import io.gravitee.reporter.api.common.Request;
 import io.gravitee.reporter.api.common.Response;
@@ -26,6 +28,7 @@ import io.gravitee.reporter.api.health.EndpointStatus;
 import io.gravitee.reporter.api.health.Step;
 import io.gravitee.reporter.api.jackson.FieldFilterMixin;
 import io.gravitee.reporter.api.jackson.FieldFilterProvider;
+import io.gravitee.reporter.api.jackson.HttpHeadersSerializer;
 import io.gravitee.reporter.file.formatter.AbstractFormatter;
 import io.vertx.core.buffer.Buffer;
 
@@ -46,6 +49,10 @@ public class JsonFormatter<T extends Reportable> extends AbstractFormatter<T> {
             mapper.addMixIn(Step.class, FieldFilterMixin.class);
             mapper.setFilterProvider(new FieldFilterProvider(rules));
         }
+
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(HttpHeaders.class, new HttpHeadersSerializer());
+        mapper.registerModule(module);
 
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }

--- a/src/test/java/io/gravitee/reporter/file/formatter/json/JsonFormatterTest.java
+++ b/src/test/java/io/gravitee/reporter/file/formatter/json/JsonFormatterTest.java
@@ -15,12 +15,16 @@
  */
 package io.gravitee.reporter.file.formatter.json;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.util.Maps;
 import io.gravitee.common.utils.UUID;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.reporter.api.common.Request;
 import io.gravitee.reporter.api.common.Response;
 import io.gravitee.reporter.api.configuration.Rules;
@@ -31,7 +35,6 @@ import java.util.Collections;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /**
@@ -95,7 +98,7 @@ public class JsonFormatterTest {
         Buffer payload = formatter.format(metrics);
 
         JsonNode node = mapper.readTree(payload.toString());
-        Assert.assertEquals(0, node.size());
+        assertEquals(0, node.size());
     }
 
     @Test
@@ -133,7 +136,7 @@ public class JsonFormatterTest {
         Buffer payload = formatter.format(metrics);
 
         JsonNode node = mapper.readTree(payload.toString());
-        Assert.assertEquals(1, node.size());
+        assertEquals(1, node.size());
         Assert.assertTrue(node.has("api"));
     }
 
@@ -160,7 +163,7 @@ public class JsonFormatterTest {
         Buffer payload = formatter.format(log);
 
         JsonNode node = mapper.readTree(payload.toString());
-        Assert.assertEquals(4, node.size());
+        assertEquals(4, node.size());
         Assert.assertFalse(node.has("clientRequest"));
     }
 
@@ -186,13 +189,13 @@ public class JsonFormatterTest {
 
         Buffer payload = formatter.format(log);
         JsonNode node = mapper.readTree(payload.toString());
-        Assert.assertEquals(5, node.size());
+        assertEquals(5, node.size());
         Assert.assertTrue(node.has("clientRequest"));
-        Assert.assertEquals(0, node.get("clientRequest").size());
+        assertEquals(0, node.get("clientRequest").size());
     }
 
     @Test
-    public void shouldRenameNestedPrgetExcludeFieldsoperty() throws JsonProcessingException {
+    public void shouldRenameNestedProperty() throws JsonProcessingException {
         Rules rules = new Rules();
         rules.setRenameFields(Maps.<String, String>builder().put("clientRequest.uri", "path").build());
 
@@ -213,10 +216,101 @@ public class JsonFormatterTest {
 
         Buffer payload = formatter.format(log);
         JsonNode node = mapper.readTree(payload.toString());
-        Assert.assertEquals(5, node.size());
+        assertEquals(5, node.size());
         Assert.assertTrue(node.has("clientRequest"));
-        Assert.assertEquals(1, node.get("clientRequest").size());
+        assertEquals(1, node.get("clientRequest").size());
         Assert.assertFalse(node.get("clientRequest").has("uri"));
         Assert.assertTrue(node.get("clientRequest").has("path"));
+    }
+
+    @Test
+    public void shouldSerializeClientRequestHeaders() throws JsonProcessingException {
+        JsonFormatter<Log> formatter = new JsonFormatter<>(null);
+
+        Log log = new Log(System.currentTimeMillis());
+        Request clientRequest = new Request();
+        HttpHeaders httpHeaders = HttpHeaders.create();
+        httpHeaders.add("header1", "value1");
+        httpHeaders.add("header2", "value2");
+        httpHeaders.add("header1", "value3");
+        clientRequest.setHeaders(httpHeaders);
+        log.setClientRequest(clientRequest);
+
+        Buffer payload = formatter.format(log);
+
+        JsonNode node = mapper.readTree(payload.toString());
+
+        assertTrue(node.has("clientRequest"));
+        assertTrue(node.get("clientRequest").has("headers"));
+        assertEquals("{\"header1\":[\"value1\",\"value3\"],\"header2\":[\"value2\"]}", node.get("clientRequest").get("headers").toString());
+    }
+
+    @Test
+    public void shouldSerializeProxyRequestHeaders() throws JsonProcessingException {
+        JsonFormatter<Log> formatter = new JsonFormatter<>(null);
+
+        Log log = new Log(System.currentTimeMillis());
+        Request proxyRequest = new Request();
+        HttpHeaders httpHeaders = HttpHeaders.create();
+        httpHeaders.add("header1", "value1");
+        httpHeaders.add("header2", "value2");
+        httpHeaders.add("header1", "value3");
+        proxyRequest.setHeaders(httpHeaders);
+        log.setProxyRequest(proxyRequest);
+
+        Buffer payload = formatter.format(log);
+
+        JsonNode node = mapper.readTree(payload.toString());
+
+        assertTrue(node.has("proxyRequest"));
+        assertTrue(node.get("proxyRequest").has("headers"));
+        assertEquals("{\"header1\":[\"value1\",\"value3\"],\"header2\":[\"value2\"]}", node.get("proxyRequest").get("headers").toString());
+    }
+
+    @Test
+    public void shouldSerializeClientResponseHeaders() throws JsonProcessingException {
+        JsonFormatter<Log> formatter = new JsonFormatter<>(null);
+
+        Log log = new Log(System.currentTimeMillis());
+        Response clientResponse = new Response();
+        HttpHeaders httpHeaders = HttpHeaders.create();
+        httpHeaders.add("header1", "value1");
+        httpHeaders.add("header2", "value2");
+        httpHeaders.add("header1", "value3");
+        clientResponse.setHeaders(httpHeaders);
+        log.setClientResponse(clientResponse);
+
+        Buffer payload = formatter.format(log);
+
+        JsonNode node = mapper.readTree(payload.toString());
+
+        assertTrue(node.has("clientResponse"));
+        assertTrue(node.get("clientResponse").has("headers"));
+        assertEquals(
+            "{\"header1\":[\"value1\",\"value3\"],\"header2\":[\"value2\"]}",
+            node.get("clientResponse").get("headers").toString()
+        );
+    }
+
+    @Test
+    public void shouldSerializeProxyResponseHeaders() throws JsonProcessingException {
+        JsonFormatter<Log> formatter = new JsonFormatter<>(null);
+
+        Log log = new Log(System.currentTimeMillis());
+        Response proxyResponse = new Response();
+        HttpHeaders httpHeaders = HttpHeaders.create();
+        httpHeaders.add("header1", "value1");
+        httpHeaders.add("header2", "value2");
+        httpHeaders.add("header1", "value3");
+        proxyResponse.setHeaders(httpHeaders);
+        log.setProxyResponse(proxyResponse);
+
+        Buffer payload = formatter.format(log);
+
+        JsonNode node = mapper.readTree(payload.toString());
+
+        assertTrue(node.has("proxyResponse"));
+        assertTrue(node.get("proxyResponse").has("headers"));
+        assertEquals("{\"header1\":[\"value1\",\"value3\"],\"header2\":[\"value2\"]}", node.get("proxyResponse").get("headers").toString());
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7741

**Description**

fix: use HttpHeadersSerializer to serialize HttpHeaders
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.5.2-fix-httpHeadersSerialization-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-file/2.5.2-fix-httpHeadersSerialization-SNAPSHOT/gravitee-reporter-file-2.5.2-fix-httpHeadersSerialization-SNAPSHOT.zip)
  <!-- Version placeholder end -->
