### PR TITLE
fix: improve accuracy of retainDays parameter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,6 +54,7 @@ Hereafter available configuration parameters:
 | *1000*
 
 | `retainDays`
-| The number of days to retain files before deleting one
+| The number of days to retain files before deletion.
+Any files with a last updated date older than this retention period are regularly deleted every day at midnight.
 | *0 (to retain forever)*
 |===

--- a/src/test/java/io/gravitee/reporter/file/vertx/VertxFileWriterTest.java
+++ b/src/test/java/io/gravitee/reporter/file/vertx/VertxFileWriterTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.file.vertx;
+
+import static io.gravitee.reporter.file.MetricsType.REQUEST;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.reporter.file.config.FileReporterConfiguration;
+import io.gravitee.reporter.file.formatter.Formatter;
+import io.vertx.core.Vertx;
+import java.io.File;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VertxFileWriterTest {
+
+    private static final ZoneOffset ZONE = ZoneOffset.UTC;
+    private static final LocalDateTime NOW = LocalDateTime.now(ZONE);
+
+    private VertxFileWriter vertxFileWriter;
+
+    @Mock
+    private FileReporterConfiguration configuration;
+
+    @Mock
+    private File file;
+
+    @Before
+    public void setup() {
+        when(configuration.getFilename()).thenReturn("/metrics/%s-yyyy_mm_dd");
+        vertxFileWriter = new VertxFileWriter(mock(Vertx.class), REQUEST, mock(Formatter.class), "filename", configuration);
+    }
+
+    @Test
+    public void shouldDeleteFile_should_return_true_if_retainDays_configuration_exceeds_file_lastModified_time() {
+        when(configuration.getRetainDays()).thenReturn(10L);
+
+        long currentTimeMs = NOW.toInstant(ZONE).toEpochMilli();
+        when(file.lastModified()).thenReturn(NOW.toInstant(ZONE).minus(10, DAYS).minus(1, SECONDS).toEpochMilli());
+
+        assertTrue(vertxFileWriter.shouldDeleteFile(file, currentTimeMs));
+    }
+
+    @Test
+    public void shouldDeleteFile_should_return_false_if_retainDays_configuration_doesnt_exceed_file_lastModified_time() {
+        when(configuration.getRetainDays()).thenReturn(10L);
+
+        long currentTimeMs = NOW.toInstant(ZONE).toEpochMilli();
+        when(file.lastModified()).thenReturn(NOW.toInstant(ZONE).minus(10, DAYS).plus(1, SECONDS).toEpochMilli());
+
+        assertFalse(vertxFileWriter.shouldDeleteFile(file, currentTimeMs));
+    }
+
+    @Test
+    public void shouldDeleteFile_should_return_false_if_retainDays_configuration_is_0() {
+        when(configuration.getRetainDays()).thenReturn(0L);
+
+        long currentTimeMs = NOW.toInstant(ZONE).toEpochMilli();
+
+        assertFalse(vertxFileWriter.shouldDeleteFile(file, currentTimeMs));
+        verify(file, never()).lastModified();
+    }
+}


### PR DESCRIPTION
**Description**

fix: improve accuracy of retainDays parameter

File should be deleted if its last modification date is older than configured retainDays.

Previous implementation with division, led to inaccuracies in delay of deletion.
For exemple, with retainDays 10, a file that had been modified 10 days + 1 hour ago, would not been deleted.

**Issue**

https://github.com/gravitee-io/issues/issues/8090

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.5.4-fix-retainDaysAccuracy-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-file/2.5.4-fix-retainDaysAccuracy-SNAPSHOT/gravitee-reporter-file-2.5.4-fix-retainDaysAccuracy-SNAPSHOT.zip)
  <!-- Version placeholder end -->
