### PR TITLE
Filter headers according to exclude/include Rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	<properties>
 		<gravitee-bom.version>2.5</gravitee-bom.version>
 		<gravitee-gateway-api.version>1.32.3</gravitee-gateway-api.version>
-		<gravitee-reporter-api.version>1.23.0</gravitee-reporter-api.version>
+		<gravitee-reporter-api.version>1.23.1</gravitee-reporter-api.version>
 		<gravitee-common.version>1.24.0</gravitee-common.version>
 		<gravitee-node.version>1.15.1</gravitee-node.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,8 +111,7 @@
 				<artifactId>prettier-maven-plugin</artifactId>
 				<version>0.18</version>
 				<configuration>
-					<nodeVersion>12.13.0</nodeVersion>
-					<prettierJavaVersion>1.0.1</prettierJavaVersion>
+					<prettierJavaVersion>1.6.2</prettierJavaVersion>
 				</configuration>
 				<executions>
 					<execution>

--- a/src/main/java/io/gravitee/reporter/file/FileReporter.java
+++ b/src/main/java/io/gravitee/reporter/file/FileReporter.java
@@ -83,15 +83,13 @@ public class FileReporter extends AbstractService implements Reporter {
 
             CompositeFuture
                 .join(writers.values().stream().map(VertxFileWriter::initialize).collect(Collectors.toList()))
-                .onComplete(
-                    event -> {
-                        if (event.succeeded()) {
-                            logger.info("File reporter successfully started");
-                        } else {
-                            logger.info("An error occurs while starting file reporter", event.cause());
-                        }
+                .onComplete(event -> {
+                    if (event.succeeded()) {
+                        logger.info("File reporter successfully started");
+                    } else {
+                        logger.info("An error occurs while starting file reporter", event.cause());
                     }
-                );
+                });
         }
     }
 
@@ -100,15 +98,13 @@ public class FileReporter extends AbstractService implements Reporter {
         if (enabled) {
             CompositeFuture
                 .join(writers.values().stream().map(VertxFileWriter::stop).collect(Collectors.toList()))
-                .onComplete(
-                    event -> {
-                        if (event.succeeded()) {
-                            logger.info("File reporter successfully stopped");
-                        } else {
-                            logger.info("An error occurs while stopping file reporter", event.cause());
-                        }
+                .onComplete(event -> {
+                    if (event.succeeded()) {
+                        logger.info("File reporter successfully stopped");
+                    } else {
+                        logger.info("An error occurs while stopping file reporter", event.cause());
                     }
-                );
+                });
         }
     }
 }

--- a/src/main/java/io/gravitee/reporter/file/formatter/json/JsonFormatter.java
+++ b/src/main/java/io/gravitee/reporter/file/formatter/json/JsonFormatter.java
@@ -51,7 +51,7 @@ public class JsonFormatter<T extends Reportable> extends AbstractFormatter<T> {
         }
 
         SimpleModule module = new SimpleModule();
-        module.addSerializer(HttpHeaders.class, new HttpHeadersSerializer());
+        module.addSerializer(HttpHeaders.class, new HttpHeadersSerializer(rules));
         mapper.registerModule(module);
 
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);

--- a/src/main/java/io/gravitee/reporter/file/vertx/VertxFileWriter.java
+++ b/src/main/java/io/gravitee/reporter/file/vertx/VertxFileWriter.java
@@ -133,13 +133,11 @@ public class VertxFileWriter<T extends Reportable> {
                     LOGGER.debug("Flush the content to file");
 
                     if (asyncFile != null) {
-                        asyncFile.flush(
-                            event1 -> {
-                                if (event1.failed()) {
-                                    LOGGER.error("An error occurs while flushing the content of the file", event1.cause());
-                                }
+                        asyncFile.flush(event1 -> {
+                            if (event1.failed()) {
+                                LOGGER.error("An error occurs while flushing the content of the file", event1.cause());
                             }
-                        );
+                        });
                     }
                 }
             );
@@ -207,17 +205,15 @@ public class VertxFileWriter<T extends Reportable> {
                                 if (oldAsyncFile != null) {
                                     // Now we can close previous file safely
                                     stop(oldAsyncFile)
-                                        .onComplete(
-                                            closeEvent -> {
-                                                if (!closeEvent.succeeded()) {
-                                                    LOGGER.error(
-                                                        "An error occurs while closing file writer for type[{}]",
-                                                        this.type,
-                                                        closeEvent.cause()
-                                                    );
-                                                }
+                                        .onComplete(closeEvent -> {
+                                            if (!closeEvent.succeeded()) {
+                                                LOGGER.error(
+                                                    "An error occurs while closing file writer for type[{}]",
+                                                    this.type,
+                                                    closeEvent.cause()
+                                                );
                                             }
-                                        );
+                                        });
                                 }
 
                                 promise.complete();
@@ -265,19 +261,17 @@ public class VertxFileWriter<T extends Reportable> {
         }
 
         stop(asyncFile)
-            .onComplete(
-                event -> {
-                    // Cancel timer
-                    vertx.cancelTimer(flushId);
+            .onComplete(event -> {
+                // Cancel timer
+                vertx.cancelTimer(flushId);
 
-                    if (event.succeeded()) {
-                        asyncFile = null;
-                        promise.complete();
-                    } else {
-                        promise.fail(event.cause());
-                    }
+                if (event.succeeded()) {
+                    asyncFile = null;
+                    promise.complete();
+                } else {
+                    promise.fail(event.cause());
                 }
-            );
+            });
 
         return promise.future();
     }
@@ -287,19 +281,16 @@ public class VertxFileWriter<T extends Reportable> {
 
         if (asyncFile != null) {
             // Ensure everything has been flushed before closing the file
-            asyncFile.flush(
-                flushEvent ->
-                    asyncFile.close(
-                        event -> {
-                            if (event.succeeded()) {
-                                LOGGER.info("File writer is now closed for type [{}]", this.type);
-                                promise.complete();
-                            } else {
-                                LOGGER.error("An error occurs while closing file writer for type[{}]", this.type, event.cause());
-                                promise.fail(event.cause());
-                            }
-                        }
-                    )
+            asyncFile.flush(flushEvent ->
+                asyncFile.close(event -> {
+                    if (event.succeeded()) {
+                        LOGGER.info("File writer is now closed for type [{}]", this.type);
+                        promise.complete();
+                    } else {
+                        LOGGER.error("An error occurs while closing file writer for type[{}]", this.type, event.cause());
+                        promise.fail(event.cause());
+                    }
+                })
             );
         } else {
             promise.complete();

--- a/src/test/java/io/gravitee/reporter/file/formatter/json/JsonFormatterTest.java
+++ b/src/test/java/io/gravitee/reporter/file/formatter/json/JsonFormatterTest.java
@@ -242,7 +242,10 @@ public class JsonFormatterTest {
 
         assertTrue(node.has("clientRequest"));
         assertTrue(node.get("clientRequest").has("headers"));
-        assertEquals("{\"header1\":[\"value1\",\"value3\"],\"header2\":[\"value2\"]}", node.get("clientRequest").get("headers").toString());
+        assertEquals(
+            mapper.readTree("{\"header1\":[\"value1\",\"value3\"],\"header2\":[\"value2\"]}"),
+            node.get("clientRequest").get("headers")
+        );
     }
 
     @Test
@@ -264,7 +267,10 @@ public class JsonFormatterTest {
 
         assertTrue(node.has("proxyRequest"));
         assertTrue(node.get("proxyRequest").has("headers"));
-        assertEquals("{\"header1\":[\"value1\",\"value3\"],\"header2\":[\"value2\"]}", node.get("proxyRequest").get("headers").toString());
+        assertEquals(
+            mapper.readTree("{\"header1\":[\"value1\",\"value3\"],\"header2\":[\"value2\"]}"),
+            node.get("proxyRequest").get("headers")
+        );
     }
 
     @Test
@@ -287,8 +293,8 @@ public class JsonFormatterTest {
         assertTrue(node.has("clientResponse"));
         assertTrue(node.get("clientResponse").has("headers"));
         assertEquals(
-            "{\"header1\":[\"value1\",\"value3\"],\"header2\":[\"value2\"]}",
-            node.get("clientResponse").get("headers").toString()
+            mapper.readTree("{\"header1\":[\"value1\",\"value3\"],\"header2\":[\"value2\"]}"),
+            node.get("clientResponse").get("headers")
         );
     }
 
@@ -311,6 +317,9 @@ public class JsonFormatterTest {
 
         assertTrue(node.has("proxyResponse"));
         assertTrue(node.get("proxyResponse").has("headers"));
-        assertEquals("{\"header1\":[\"value1\",\"value3\"],\"header2\":[\"value2\"]}", node.get("proxyResponse").get("headers").toString());
+        assertEquals(
+            mapper.readTree("{\"header1\":[\"value1\",\"value3\"],\"header2\":[\"value2\"]}"),
+            node.get("proxyResponse").get("headers")
+        );
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8226

**Description**

Update `gravitee-reporter-api` and use correct constructor to instantiate `HttpHeadersSerializer`
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.5.5-8226-fix-filter-on-headers-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-file/2.5.5-8226-fix-filter-on-headers-SNAPSHOT/gravitee-reporter-file-2.5.5-8226-fix-filter-on-headers-SNAPSHOT.zip)
  <!-- Version placeholder end -->
