### PR TITLE
fix: bump gravitee-reporter-common to fix espace issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<gravitee-bom.version>6.0.4</gravitee-bom.version>
 		<gravitee-gateway-api.version>3.1.0</gravitee-gateway-api.version>
 		<gravitee-reporter-api.version>1.26.0</gravitee-reporter-api.version>
-		<gravitee-reporter-common.version>1.0.0</gravitee-reporter-common.version>
+		<gravitee-reporter-common.version>1.0.4</gravitee-reporter-common.version>
 		<gravitee-common.version>3.0.0</gravitee-common.version>
 		<gravitee-node.version>4.1.0</gravitee-node.version>
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3180

**Description**

for APIM 4.0 & 4.1

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.1-APIM-3180-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-file/3.0.1-APIM-3180-SNAPSHOT/gravitee-reporter-file-3.0.1-APIM-3180-SNAPSHOT.zip)
  <!-- Version placeholder end -->
