### PR TITLE
fix: bump reporter-common for Monitor issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<gravitee-bom.version>6.0.35</gravitee-bom.version>
 		<gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
 		<gravitee-reporter-api.version>1.28.1</gravitee-reporter-api.version>
-		<gravitee-reporter-common.version>1.0.5</gravitee-reporter-common.version>
+		<gravitee-reporter-common.version>1.0.6</gravitee-reporter-common.version>
 		<gravitee-common.version>3.4.1</gravitee-common.version>
 		<gravitee-node.version>4.8.3</gravitee-node.version>
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4083
https://github.com/gravitee-io/issues/issues/9589

**Description**

Bump reporter-common to fix Monitor issue
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.3-apim-4083-use-right-monitor-class-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-file/3.0.3-apim-4083-use-right-monitor-class-SNAPSHOT/gravitee-reporter-file-3.0.3-apim-4083-use-right-monitor-class-SNAPSHOT.zip)
  <!-- Version placeholder end -->
