### PR TITLE
feat: report entrypoint id in v4 metrics index

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<gravitee-bom.version>6.0.42</gravitee-bom.version>
 		<gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
 		<gravitee-reporter-api.version>1.29.0</gravitee-reporter-api.version>
-		<gravitee-reporter-common.version>1.0.6</gravitee-reporter-common.version>
+		<gravitee-reporter-common.version>1.1.0</gravitee-reporter-common.version>
 		<gravitee-common.version>3.4.1</gravitee-common.version>
 		<gravitee-node.version>4.8.5</gravitee-node.version>
 


### PR DESCRIPTION


**Issue**

https://gravitee.atlassian.net/browse/APIM-3481

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.0-apim-3481-add-entrypoint-id-to-metrics-v4-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-file/3.1.0-apim-3481-add-entrypoint-id-to-metrics-v4-SNAPSHOT/gravitee-reporter-file-3.1.0-apim-3481-add-entrypoint-id-to-metrics-v4-SNAPSHOT.zip)
  <!-- Version placeholder end -->
