### PR TITLE
fix: bump reporter-common for Monitor issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
 	<groupId>io.gravitee.reporter</groupId>
 	<artifactId>gravitee-reporter-file</artifactId>
-	<version>3.2.0</version>
+	<version>3.2.1-apim-4595-fix-node-monitoring-SNAPSHOT</version>
 
 	<name>Gravitee.io APIM - Reporter - File</name>
 
@@ -36,7 +36,7 @@
 		<gravitee-bom.version>6.0.47</gravitee-bom.version>
 		<gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
 		<gravitee-reporter-api.version>1.30.0</gravitee-reporter-api.version>
-		<gravitee-reporter-common.version>1.2.0</gravitee-reporter-common.version>
+		<gravitee-reporter-common.version>1.2.1</gravitee-reporter-common.version>
 		<gravitee-common.version>3.4.1</gravitee-common.version>
 		<gravitee-node.version>4.8.6</gravitee-node.version>
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4595

**Description**

Bump reporter-common to use only reporter/Monitor class and not node/Monitor
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.2.1-apim-4595-fix-node-monitoring-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-file/3.2.1-apim-4595-fix-node-monitoring-SNAPSHOT/gravitee-reporter-file-3.2.1-apim-4595-fix-node-monitoring-SNAPSHOT.zip)
  <!-- Version placeholder end -->
