### PR TITLE
fix(deps): bump gravitee-reporter-api to 1.34.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 	<properties>
 		<gravitee-bom.version>8.3.0</gravitee-bom.version>
 		<gravitee-apim.version>4.7.4</gravitee-apim.version>
-		<gravitee-reporter-api.version>1.33.1</gravitee-reporter-api.version>
+		<gravitee-reporter-api.version>1.34.0</gravitee-reporter-api.version>
 		<gravitee-reporter-common.version>1.6.0</gravitee-reporter-common.version>
 		<gravitee-node.version>4.8.9</gravitee-node.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<gravitee-bom.version>8.3.0</gravitee-bom.version>
 		<gravitee-apim.version>4.7.4</gravitee-apim.version>
 		<gravitee-reporter-api.version>1.34.0</gravitee-reporter-api.version>
-		<gravitee-reporter-common.version>1.6.0</gravitee-reporter-common.version>
+		<gravitee-reporter-common.version>1.6.2</gravitee-reporter-common.version>
 		<gravitee-node.version>4.8.9</gravitee-node.version>
 
 		<maven-plugin-assembly.version>3.7.1</maven-plugin-assembly.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/9748

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.5.2-bump-reporter-api-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-file/3.5.2-bump-reporter-api-SNAPSHOT/gravitee-reporter-file-3.5.2-bump-reporter-api-SNAPSHOT.zip)
  <!-- Version placeholder end -->
