### PR TITLE
fix: fix dependencies management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,7 @@
 
 	<properties>
 		<gravitee-bom.version>8.3.0</gravitee-bom.version>
-		<gravitee-apim.version>4.7.4</gravitee-apim.version>
-		<gravitee-reporter-api.version>1.34.0</gravitee-reporter-api.version>
+		<gravitee-apim.version>4.7.6</gravitee-apim.version>
 		<gravitee-reporter-common.version>1.6.2</gravitee-reporter-common.version>
 		<gravitee-node.version>4.8.9</gravitee-node.version>
 
@@ -115,7 +114,7 @@
 		<dependency>
 			<groupId>io.gravitee.reporter</groupId>
 			<artifactId>gravitee-reporter-api</artifactId>
-			<version>${gravitee-reporter-api.version}</version>
+			<!-- don’t override the version, MUST be provided by APIM -->
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-9866

**Description**

Ensure get the dependencies provided by APIM from APIM BOM
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.5.3-apim-9866-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-file/3.5.3-apim-9866-SNAPSHOT/gravitee-reporter-file-3.5.3-apim-9866-SNAPSHOT.zip)
  <!-- Version placeholder end -->
