### PR TITLE
fix: bump gravitee-reporter-common version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>io.gravitee</groupId>
 		<artifactId>gravitee-parent</artifactId>
-		<version>22.4.1</version>
+		<version>22.5.1</version>
 	</parent>
 
 	<groupId>io.gravitee.reporter</groupId>
@@ -35,7 +35,7 @@
 	<properties>
 		<gravitee-bom.version>8.3.0</gravitee-bom.version>
 		<gravitee-apim.version>4.8.2</gravitee-apim.version>
-		<gravitee-reporter-common.version>1.6.2</gravitee-reporter-common.version>
+		<gravitee-reporter-common.version>1.6.3</gravitee-reporter-common.version>
 		<gravitee-node.version>4.8.9</gravitee-node.version>
 
 		<maven-plugin-assembly.version>3.7.1</maven-plugin-assembly.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-10459
**Description**

bump gravitee-reporter-common to 1.6.3

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.5.4-APIM-10459-fix-bump-reporter-common-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-file/3.5.4-APIM-10459-fix-bump-reporter-common-SNAPSHOT/gravitee-reporter-file-3.5.4-APIM-10459-fix-bump-reporter-common-SNAPSHOT.zip)
  <!-- Version placeholder end -->
