### PR TITLE
fix: bump gravitee-reporter-common version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 	<properties>
 		<gravitee-bom.version>8.3.34</gravitee-bom.version>
 		<gravitee-apim.version>4.8.4</gravitee-apim.version>
-		<gravitee-reporter-common.version>1.6.3</gravitee-reporter-common.version>
+		<gravitee-reporter-common.version>1.6.4</gravitee-reporter-common.version>
 		<gravitee-node.version>4.8.9</gravitee-node.version>
 
 		<maven-plugin-assembly.version>3.7.1</maven-plugin-assembly.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-10943

**Description**

fix: bump gravitee-reporter-common

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.5.5-APIM-10943-fix-reporter-fails-with-ES7-and-V4-Proxy-API-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-file/3.5.5-APIM-10943-fix-reporter-fails-with-ES7-and-V4-Proxy-API-SNAPSHOT/gravitee-reporter-file-3.5.5-APIM-10943-fix-reporter-fails-with-ES7-and-V4-Proxy-API-SNAPSHOT.zip)
  <!-- Version placeholder end -->
