### PR TITLE
update readme with versioning and compatibility info

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,15 @@ https://github.com/gravitee-io/issues/issues/XXXXX
 
 A small description of what you did in that PR.
 
+> [!WARNING]
+> Major version 4.x is the latest version available for this repository.
+>
+> ⚠️**No new major version should be released.**
+>
+> Starting with APIM 4.11.0, `gravitee-reporter-common`, `gravitee-reporter-elasticsearch` and `gravitee-reporter-file` have been added as maven modules in the APIM monorepo.
+>
+> As a consequence, **all bug fixes** that are merged into `gravitee-reporter-file` have to be cherry-picked in the [APIM monorepo](https://github.com/gravitee-io/gravitee-api-management).
+
 **Additional context**
 
 <!-- Add any other context about the PR here -->

--- a/README.adoc
+++ b/README.adoc
@@ -8,6 +8,17 @@ image:https://circleci.com/gh/gravitee-io/gravitee-reporter-file.svg?style=svg["
 image:https://f.hubspotusercontent40.net/hubfs/7600448/gravitee-github-button.jpg["Join the community forum", link="https://community.gravitee.io?utm_source=readme", height=20]
 endif::[]
 
+[WARNING]
+====
+Major version 4.x is the latest version available for this repository.
+
+⚠️**No new major version should be released.**
+
+Starting with APIM 4.11.0, `gravitee-reporter-common`, `gravitee-reporter-elasticsearch` and `gravitee-reporter-file` have been added as maven modules in the [APIM monorepo](https://github.com/gravitee-io/gravitee-api-management).
+ 
+As a consequence, **all bug fixes** that are merged into `gravitee-reporter-file` have to be cherry-picked in the [APIM monorepo](https://github.com/gravitee-io/gravitee-api-management).
+====
+
 
 == Presentation
 
@@ -16,11 +27,11 @@ This reporter writes access logs to a file, by corresponding one line to one req
 == Compatibility matrix
 
 |===
-|Plugin version    | APIM version | JDK version
+|Plugin version    | APIM version     | JDK version
 
-| 4.x              | 10.x         | 17
-| 3.x              | 4.x          | 17
-| 2.x              | 3.x          | 8
+| 4.x              | 4.10.x           | 17
+| 3.x              | 4.0.x to 4.9.x   | 17
+| 2.x              | 3.x              | 8
 |===
 
 


### PR DESCRIPTION
Starting with APIM 4.11.0, reporter-common, reporter-file and reporter-elasticsearch have been added as maven module in apim monorepo.

This PR updates the README to add a warning about that change.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.1`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-file/4.0.1/gravitee-reporter-file-4.0.1.zip)
  <!-- Version placeholder end -->
