### PR TITLE
fix: bump reporter-common to 2.0.2 to fix msgpack security vulnerability (APIM-12726)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
 	<properties>
 		<gravitee-apim.version>4.11.4</gravitee-apim.version>
-		<gravitee-reporter-common.version>2.0.1</gravitee-reporter-common.version>
+		<gravitee-reporter-common.version>2.0.2</gravitee-reporter-common.version>
 		<gravitee-node.version>4.8.9</gravitee-node.version>
 
         <!-- Property used by the publication job in CI-->


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12726

**Description**

A small description of what you did in that PR.

> [!WARNING]
> Major version 4.x is the latest version available for this repository.
>
> ⚠️**No new major version should be released.**
>
> Starting with APIM 4.11.0, `gravitee-reporter-common`, `gravitee-reporter-elasticsearch` and `gravitee-reporter-file` have been added as maven modules in the APIM monorepo.
>
> As a consequence, **all bug fixes** that are merged into `gravitee-reporter-file` have to be cherry-picked in the [APIM monorepo](https://github.com/gravitee-io/gravitee-api-management).

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
